### PR TITLE
Refactor

### DIFF
--- a/src/mpi.f90
+++ b/src/mpi.f90
@@ -260,7 +260,7 @@ module mpi
         end subroutine
 
         subroutine MPI_Irecv_proc(buf, count, datatype, source, tag, comm, request, ierror)
-            real(8), dimension(..) :: buf
+            real(8), dimension(:,:) :: buf
             integer, intent(in) :: count, source, tag
             integer, intent(in) :: datatype
             integer, intent(in) :: comm

--- a/src/mpi_c_bindings.f90
+++ b/src/mpi_c_bindings.f90
@@ -21,20 +21,22 @@ module mpi_c_bindings
             integer(c_int), optional, intent(out) :: ierror
         end subroutine
 
-        subroutine c_mpi_allgather_int(sendbuf, sendcount, sendtype, recvbuf, recvcount, recvtype, comm, ierror) bind(C, name="MPI_Allgather")
+        subroutine c_mpi_allgather_int(sendbuf, sendcount, sendtype, recvbuf, &
+                                       recvcount, recvtype, comm, ierror) bind(C, name="MPI_Allgather")
             import :: c_int, c_double
             integer(c_int), dimension(:), intent(in) :: sendbuf
-            integer(c_int), dimension(:, :) :: recvbuf
+            integer(c_int), dimension(*) :: recvbuf
             integer(c_int), intent(in) :: sendcount, recvcount
             integer(c_int), intent(in) :: sendtype, recvtype
             integer(c_int), intent(in) :: comm
             integer(c_int), optional, intent(out) :: ierror
         end subroutine
 
-        subroutine c_mpi_allgather_real(sendbuf, sendcount, sendtype, recvbuf, recvcount, recvtype, comm, ierror) bind(C, name="MPI_Allgather")
+        subroutine c_mpi_allgather_real(sendbuf, sendcount, sendtype, recvbuf, &
+                                        recvcount, recvtype, comm, ierror) bind(C, name="MPI_Allgather")
             import :: c_int, c_double
             real(c_double), dimension(:), intent(in) :: sendbuf
-            real(c_double), dimension(:, :) :: recvbuf
+            real(c_double), dimension(*) :: recvbuf
             integer(c_int), intent(in) :: sendcount, recvcount
             integer(c_int), intent(in) :: sendtype, recvtype
             integer(c_int), intent(in) :: comm


### PR DESCRIPTION
With This PR 

```clojure
 aditya-trivedi   src    mpi_lf4 ≡  ~2    lfortran -c mpi_c_bindings.f90
 aditya-trivedi   src    mpi_lf4 ≡  ~2    lfortran -c mpi.f90
 aditya-trivedi   src    mpi_lf4 ≡  ~2    lfortran -c psi_io.f90 --no-style-warnings --no-warnings
 aditya-trivedi   src    mpi_lf4 ≡  ~2    gfortran -c mpi_c_bindings.f90
 aditya-trivedi   src    mpi_lf4 ≡  ~2    gfortran -c mpi.f90
 aditya-trivedi   src    mpi_lf4 ≡  ~2    gfortran -c psi_io.f90 
 aditya-trivedi   src    mpi_lf4 ≡  ~2    gfortran -c pot3d.F
```
On lf4

```clojure
 aditya-trivedi   src    mpi_lf4o ≡    lfortran -c mpi_c_bindings.f90
 aditya-trivedi   src    mpi_lf4o ≡    lfortran -c mpi.f90
 aditya-trivedi   src    mpi_lf4o ≡    gfortran -c mpi_c_bindings.f90
mpi_c_bindings.f90:24:132:

   24 |         subroutine c_mpi_allgather_int(sendbuf, sendcount, sendtype, recvbuf, recvcount, recvtype, comm, ierror) bind(C, name="MPI_Allgather")
      |                                                                                                                                    1
Error: Line truncated at (1) [-Werror=line-truncation]
mpi_c_bindings.f90:24:128:

   24 |         subroutine c_mpi_allgather_int(sendbuf, sendcount, sendtype, recvbuf, recvcount, recvtype, comm, ierror) bind(C, name="MPI_Allgather")
      |                                                                                                                                1
Error: Unterminated character constant beginning at (1)
mpi_c_bindings.f90:25:19:

   25 |             import :: c_int, c_double
      |                   1
Error: IMPORT statement at (1) only permitted in an INTERFACE body
mpi_c_bindings.f90:26:20:

   26 |             integer(c_int), dimension(:), intent(in) :: sendbuf
      |                    1
Error: Parameter ‘c_int’ at (1) has not been declared or is a variable, which does not reduce to a constant expression
mpi_c_bindings.f90:27:20:

   27 |             integer(c_int), dimension(:, :) :: recvbuf
      |                    1
Error: Parameter ‘c_int’ at (1) has not been declared or is a variable, which does not reduce to a constant expression
mpi_c_bindings.f90:28:20:

   28 |             integer(c_int), intent(in) :: sendcount, recvcount
      |                    1
Error: Parameter ‘c_int’ at (1) has not been declared or is a variable, which does not reduce to a constant expression
mpi_c_bindings.f90:29:20:

   29 |             integer(c_int), intent(in) :: sendtype, recvtype
      |                    1
Error: Parameter ‘c_int’ at (1) has not been declared or is a variable, which does not reduce to a constant expression
mpi_c_bindings.f90:30:20:

   30 |             integer(c_int), intent(in) :: comm
      |                    1
Error: Parameter ‘c_int’ at (1) has not been declared or is a variable, which does not reduce to a constant expression
mpi_c_bindings.f90:31:20:

   31 |             integer(c_int), optional, intent(out) :: ierror
      |                    1
Error: Parameter ‘c_int’ at (1) has not been declared or is a variable, which does not reduce to a constant expression
mpi_c_bindings.f90:32:11:

   32 |         end subroutine
      |           1
Error: Expecting END INTERFACE statement at (1)
mpi_c_bindings.f90:34:132:

   34 |         subroutine c_mpi_allgather_real(sendbuf, sendcount, sendtype, recvbuf, recvcount, recvtype, comm, ierror) bind(C, name="MPI_Allgather")
      |                                                                                                                                    1
Error: Line truncated at (1) [-Werror=line-truncation]
mpi_c_bindings.f90:34:129:

   34 |         subroutine c_mpi_allgather_real(sendbuf, sendcount, sendtype, recvbuf, recvcount, recvtype, comm, ierror) bind(C, name="MPI_Allgather")
      |                                                                                                                                 1
Error: Unterminated character constant beginning at (1)
mpi_c_bindings.f90:35:19:

   35 |             import :: c_int, c_double
      |                   1
Error: IMPORT statement at (1) only permitted in an INTERFACE body
mpi_c_bindings.f90:36:17:

   36 |             real(c_double), dimension(:), intent(in) :: sendbuf
      |                 1
Error: Parameter ‘c_double’ at (1) has not been declared or is a variable, which does not reduce to a constant expression
mpi_c_bindings.f90:37:17:

   37 |             real(c_double), dimension(:, :) :: recvbuf
      |                 1
Error: Parameter ‘c_double’ at (1) has not been declared or is a variable, which does not reduce to a constant expression
mpi_c_bindings.f90:38:20:

   38 |             integer(c_int), intent(in) :: sendcount, recvcount
      |                    1
Error: Parameter ‘c_int’ at (1) has not been declared or is a variable, which does not reduce to a constant expression
mpi_c_bindings.f90:39:20:

   39 |             integer(c_int), intent(in) :: sendtype, recvtype
      |                    1
Error: Parameter ‘c_int’ at (1) has not been declared or is a variable, which does not reduce to a constant expression
mpi_c_bindings.f90:40:20:

   40 |             integer(c_int), intent(in) :: comm
      |                    1
Error: Parameter ‘c_int’ at (1) has not been declared or is a variable, which does not reduce to a constant expression
mpi_c_bindings.f90:41:20:

   41 |             integer(c_int), optional, intent(out) :: ierror
      |                    1
Error: Parameter ‘c_int’ at (1) has not been declared or is a variable, which does not reduce to a constant expression
mpi_c_bindings.f90:42:11:

   42 |         end subroutine
      |           1
Error: Expecting END INTERFACE statement at (1)
f951: some warnings being treated as errors

```