### PR TITLE
build: link mpi library separately to allow use of other compilers

### DIFF
--- a/build_examples/build_cpu_mpi-only_gcc_macos_homebrew_lf.sh
+++ b/build_examples/build_cpu_mpi-only_gcc_macos_homebrew_lf.sh
@@ -43,7 +43,7 @@ HDF5_LIB_FLAGS="-lhdf5_fortran -lhdf5_hl_fortran -lhdf5 -lhdf5_hl"
 # Please set the compile flags based on your compiler and hardware setup.
 ###########################################################################
 
-FFLAGS="O3 -march=native -lmpi"
+FFLAGS="-O3 -march=native -lmpi"
 
 ###########################################################################
 # If using NV HPC SDK for GPUs, with CUDA version >= 11.3, you can set 

--- a/build_examples/build_cpu_mpi-only_gcc_macos_homebrew_lf.sh
+++ b/build_examples/build_cpu_mpi-only_gcc_macos_homebrew_lf.sh
@@ -19,7 +19,7 @@
 # Enter your MPI compiler (typically "mpif90").
 #################################################################
 
-FC=mpif90
+FC=gfortran
 MPICC=mpicc
 
 #################################################################
@@ -43,7 +43,7 @@ HDF5_LIB_FLAGS="-lhdf5_fortran -lhdf5_hl_fortran -lhdf5 -lhdf5_hl"
 # Please set the compile flags based on your compiler and hardware setup.
 ###########################################################################
 
-FFLAGS="-O3 -march=native"
+FFLAGS="O3 -march=native -lmpi"
 
 ###########################################################################
 # If using NV HPC SDK for GPUs, with CUDA version >= 11.3, you can set 


### PR DESCRIPTION
## Description

Shamelessly copied the changes from https://github.com/gxyd/POT3D/pull/24 , this PR applied those changes to macOS, since CI already tests it on macOS, these changes should probably be fine.