### PR TITLE
build: set compiler as default to GFortran, unless specified otherwise

### DIFF
--- a/build_examples/build_cpu_mpi-only_gcc_macos_homebrew_lf.sh
+++ b/build_examples/build_cpu_mpi-only_gcc_macos_homebrew_lf.sh
@@ -46,7 +46,9 @@ HDF5_LIB_FLAGS="-lhdf5_fortran -lhdf5_hl_fortran -lhdf5 -lhdf5_hl"
 
 # this is how FFLAGS is originally set in POT3D repository
 # FFLAGS = "-O3 -march=native"
-if [[ $FC == "gfortran" ]]; then
+
+# we check whether "FC" contains "gfortran" or not
+if echo "$FC" | grep -iq "gfortran"; then
   FFLAGS="-O3 -march=native -lmpi"
 else
   FFLAGS="-lmpi"

--- a/build_examples/build_cpu_mpi-only_gcc_macos_homebrew_lf.sh
+++ b/build_examples/build_cpu_mpi-only_gcc_macos_homebrew_lf.sh
@@ -19,7 +19,8 @@
 # Enter your MPI compiler (typically "mpif90").
 #################################################################
 
-FC=gfortran
+# Set FC to gfortran if it's not already set
+: ${FC:=gfortran}
 MPICC=mpicc
 
 #################################################################
@@ -43,7 +44,13 @@ HDF5_LIB_FLAGS="-lhdf5_fortran -lhdf5_hl_fortran -lhdf5 -lhdf5_hl"
 # Please set the compile flags based on your compiler and hardware setup.
 ###########################################################################
 
-FFLAGS="-O3 -march=native -lmpi"
+# this is how FFLAGS is originally set in POT3D repository
+# FFLAGS = "-O3 -march=native"
+if [[ $FC == "gfortran" ]]; then
+  FFLAGS="-O3 -march=native -lmpi"
+else
+  FFLAGS="-lmpi"
+fi
 
 ###########################################################################
 # If using NV HPC SDK for GPUs, with CUDA version >= 11.3, you can set 
@@ -73,6 +80,7 @@ cY="\033[1;93m"
 Bl="\033[1;5;96m"
 echo="echo -e"
 
+${echo} "==> Using Fortran compiler: ${cC}${FC}${cX}"
 ${echo} "${cG}=== STARTING POT3D BUILD ===${cX}"
 ${echo} "==> Entering src directory..."
 pushd ${POT3D_HOME}/src > /dev/null

--- a/src/Makefile.template
+++ b/src/Makefile.template
@@ -34,7 +34,11 @@ clean:
 	rm pot3d 2>/dev/null
 
 pot3d_cpp.f90: pot3d.F90
-	$(FC) -E -cpp $(IF_DEF) > pot3d_cpp.f90 $<
+	@if echo "$(FC)" | grep -iq "gfortran"; then \
+		$(FC) -E -cpp $(IF_DEF) > pot3d_cpp.f90 $<; \
+	else \
+		$(FC) -E --cpp $(IF_DEF) > pot3d_cpp.f90 $<; \
+	fi
 
 psi_io.o: psi_io.f90
 	$(FC) -c $(FFLAGS) $<


### PR DESCRIPTION
## Description

This sets the default compiler as GFortran, unless one want to use some other compiler like `LFortran`, then that needs to be specified using `export FC=lfortran` etc.