### PR TITLE
build: add validate_lf.sh which only run MPI rank 1 without comparison

### DIFF
--- a/validate_lf.sh
+++ b/validate_lf.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+set -ex
 
 POT3D_HOME=$PWD
 TEST="validation"

--- a/validate_lf.sh
+++ b/validate_lf.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+POT3D_HOME=$PWD
+TEST="validation"
+MPIEXEC=${CONDA_PREFIX}/bin/mpiexec
+
+cp ${POT3D_HOME}/testsuite/${TEST}/input/* ${POT3D_HOME}/testsuite/${TEST}/run/
+cd ${POT3D_HOME}/testsuite/${TEST}/run
+
+echo "Running POT3D with 1 MPI rank..."
+${MPIEXEC} -np 1 ${POT3D_HOME}/bin/pot3d 1> pot3d.log 2>pot3d.err
+echo "Done!"
+
+runtime=($(tail -n 5 timing.out | head -n 1))
+echo "Wall clock time:                ${runtime[6]} seconds"
+echo " "


### PR DESCRIPTION
validate_lf.sh only runs mpi with rank 1 and without comparing the generated output with the saved output