### PR TITLE
UNDO XX Revert "XX: workaround, no need to use 'contiguous' attribute"

### DIFF
--- a/src/psi_io.f90
+++ b/src/psi_io.f90
@@ -33,7 +33,7 @@ module rp1d_def
       implicit none
 !
       type :: rp1d
-        real(REAL64), dimension(:), pointer :: f
+        real(REAL64), dimension(:), pointer, contiguous :: f
       end type
 !
 end module
@@ -58,7 +58,7 @@ module sds_def
         logical :: hdf32
       !   type(rp1d), dimension(mxdim) :: scales
         real(REAL64), dimension(:,:), pointer :: scales
-        real(REAL64), dimension(:,:,:), pointer :: f
+        real(REAL64), dimension(:,:,:), pointer, contiguous :: f
       end type
 !
 end module


### PR DESCRIPTION
## Description

This reverts commit https://github.com/gxyd/POT3D/commit/72bf9802cc2f3b700e89afb98b05f9bf49af617c