### PR TITLE
UNDO XX Revert "XX: Add print statement before MPI_* calls fixes segfaults (#56)"

### DIFF
--- a/src/pot3d.F90
+++ b/src/pot3d.F90
@@ -5761,9 +5761,6 @@ subroutine seam_hhh (a)
 !
       lbuf=nr*nt
 !
-      ! [XX: This print statement removes segfault which is wierd but good workaround for now]
-      print *,"Dummy print statement with bounds od a", lbound(a), ubound(a)
-
 !$omp target data use_device_ptr(a)
       call MPI_Isend (a(:,:,np-1),lbuf,ntype_real,iproc_pp,tag, &
                       comm_all,reqs(1),ierr)


### PR DESCRIPTION
## Description

This reverts commit 432ee83a1a33f0e066063c3c4082eee2b80b6e48.